### PR TITLE
MGS4: DualShock 3 support - pressure-sensitive buttons, rumble and shake

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -1,4 +1,4 @@
-// ============================================================================
+﻿// ============================================================================
 // Project:   Universal Config Tool
 // File:      tab_data.cpp
 //
@@ -43,6 +43,9 @@ const std::vector<std::pair<wxString, std::vector<Field>>> kTabs = {
         { (MGS4|MGSPW), ConfigKeys::LauncherSkip_Section, ConfigKeys::LauncherSkip_Setting, ConfigKeys::LauncherSkip_Help, ConfigKeys::LauncherSkip_Tooltip,
           std::nullopt, false, Field::Choice, 0, 0, 0, ConfigKeys::LauncherSkip_Option_Disabled,
           {ConfigKeys::LauncherSkip_Option_Disabled, ConfigKeys::LauncherSkip_Option_GameStart, ConfigKeys::LauncherSkip_Option_DatabaseStart} },
+
+        { (MGS4), ConfigKeys::Ds3Support_Section, ConfigKeys::Ds3Support_Setting, ConfigKeys::Ds3Support_Help, ConfigKeys::Ds3Support_Tooltip,
+          std::nullopt, false, Field::Bool, false },
 
 
     }},

--- a/MGSPatriotFix.vcxproj
+++ b/MGSPatriotFix.vcxproj
@@ -12,6 +12,9 @@
     <ClCompile Include="src\resources\game_funcs.cpp" />
     <ClCompile Include="src\fixes\resolution_scaling_fixes.cpp" />
     <ClCompile Include="src\fixes\graphics_tuning.cpp" />
+    <ClCompile Include="src\fixes\pressure_inputs.cpp" />
+    <ClCompile Include="src\fixes\ds3_rumble.cpp" />
+    <ClCompile Include="src\fixes\pad_motion.cpp" />
     <ClCompile Include="src\warnings\background_shuffle_warning.cpp" />
     <ClCompile Include="src\resources\input_handler.cpp" />
     <ClCompile Include="src\resources\config.cpp" />
@@ -59,6 +62,9 @@
     <ClInclude Include="src\features\launcher_skips_and_starts.hpp" />
     <ClInclude Include="src\fixes\resolution_scaling_fixes.hpp" />
     <ClInclude Include="src\fixes\graphics_tuning.hpp" />
+    <ClInclude Include="src\fixes\pressure_inputs.hpp" />
+    <ClInclude Include="src\fixes\ds3_rumble.hpp" />
+    <ClInclude Include="src\fixes\pad_motion.hpp" />
     <ClInclude Include="src\resources\d3d11_text_overlay.hpp" />
     <ClInclude Include="src\resources\game_defines.hpp" />
     <ClInclude Include="src\resources\game_funcs.hpp" />

--- a/MGSPatriotFix.vcxproj.filters
+++ b/MGSPatriotFix.vcxproj.filters
@@ -65,6 +65,15 @@
     <ClCompile Include="src\fixes\resolution_scaling_fixes.cpp">
       <Filter>Fixes</Filter>
     </ClCompile>
+    <ClCompile Include="src\fixes\pressure_inputs.cpp">
+      <Filter>Fixes</Filter>
+    </ClCompile>
+    <ClCompile Include="src\fixes\ds3_rumble.cpp">
+      <Filter>Fixes</Filter>
+    </ClCompile>
+    <ClCompile Include="src\fixes\pad_motion.cpp">
+      <Filter>Fixes</Filter>
+    </ClCompile>
     <ClCompile Include="src\warnings\windows_multiplane_overlay_warning.cpp">
       <Filter>Warnings</Filter>
     </ClCompile>
@@ -171,6 +180,14 @@
     </ClInclude>
     <ClInclude Include="src\features\launcher_skips_and_starts.hpp">
       <Filter>Features\Headers</Filter>
+    <ClInclude Include="src\fixes\pressure_inputs.hpp">
+      <Filter>Fixes\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\fixes\ds3_rumble.hpp">
+      <Filter>Fixes\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\fixes\pad_motion.hpp">
+      <Filter>Fixes\Headers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This is bugfix mod for the Metal Gear Solid Master Collection: Volume 2 versions
 > [!NOTE]
 (More features and fixes are added frequently and may be missing from this list.)
 
+#### MGS4 Features:
+- DualShock 3 support (pressure-sensitive face buttons/triggers, rumble, and motion for shake actions such as resetting the OctoCamo.) See [DualShock 3 Setup](#dualshock-3-setup).
+
 ## Bug Fixes
 #### Shared Bugs:
 - Fixes the monitor going to sleep during long cutscenes (for Windows only, Linux needs to be [fixed by Valve](https://github.com/ValveSoftware/Proton/issues/8881).)
@@ -64,6 +67,31 @@ This is bugfix mod for the Metal Gear Solid Master Collection: Volume 2 versions
 ### Configuration
 
 - See **MGSPatriotFix Config Tool.exe** in the game's root folder to adjust settings for the fix.
+
+
+## DualShock 3 Setup
+### Windows:
+
+ - Download and install [DsHidMini](https://docs.nefarius.at/projects/DsHidMini/)
+ - Set DsHidMini to SXS mode.
+
+  (This matches the configuration required for PCSX2. If your DS3 controller is already set up properly with PCSX2, then you're already good to go!)
+
+### Steam Deck / Linux:
+> [!NOTE]
+**🚩 These steps are only needed if you’re on Steam Deck/Linux. Skip if you’re using Windows.**
+
+ The pad works out of the box, but Steam needs to be told to prefer it.
+
+ Step 1)
+  - Open up the game properties of MGS4 in Steam and set the following line to the launch options:
+
+        SDL_GAMECONTROLLER_IGNORE_DEVICES= PROTON_ENABLE_HIDRAW=0x054C/0x0268 WINEDLLOVERRIDES="winmm=n,b" %command%
+
+ Step 2)
+  - Open the Steam overlay while the game is running.
+  - Open controller settings.
+  - Click reorder controllers, and select the PS3 controller as your primary device.
 
 
 ## Support

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -19,6 +19,9 @@
 #include "resolution_scaling_fixes.hpp"
 #include "graphics_tuning.hpp"
 #include "launcher_skips_and_starts.hpp"
+#include "pressure_inputs.hpp"
+#include "pad_motion.hpp"
+#include "ds3_rumble.hpp"
 
 //Warnings
 #include "asi_loader_checks.hpp"
@@ -154,6 +157,9 @@ namespace
         {
 
             //INITIALIZE(ResolutionScalingFixes::ApplyFixes());
+            INITIALIZE(PressureInputs::Initialize());
+            INITIALIZE(PadMotion::Initialize());
+            INITIALIZE(Ds3Rumble::Initialize());
 
         }
         else if (eGameType & MGSPW)

--- a/src/fixes/ds3_rumble.cpp
+++ b/src/fixes/ds3_rumble.cpp
@@ -1,0 +1,250 @@
+#include "stdafx.h"
+#include "ds3_rumble.hpp"
+#include "pressure_inputs.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+#include <Xinput.h>
+#include <hidsdi.h>
+#include <hidpi.h>
+#pragma comment(lib, "hid.lib")
+
+// The game rumbles through XInput, which cannot see a DsHidMini DualShock 3. Take the motor values
+// on their way to XInput and write them to the pad directly.
+namespace
+{
+    // High byte small motor 0/1, low byte big motor 0-255.
+    std::atomic<uint16_t> gMotors = 0;
+    HANDLE gWake = nullptr;
+    SafetyHookMid gSinkHook {};
+
+    HANDLE gDev = nullptr;
+    USHORT gReportLen = 0;
+    int gMode = -1;     // kProfiles index: 0 SXS, 1 SDF, 2 native
+
+    // The DS3's big motor stalls below ~1/3 throttle; lift nonzero levels onto the band that spins.
+    constexpr int kBigMotorFloor = 96;
+
+    uint8_t BigMotorCurve(uint8_t value)
+    {
+        const int scaled = std::min(255, value * Ds3Rumble::iStrength / 100);
+        return scaled ? static_cast<uint8_t>(kBigMotorFloor + scaled * (255 - kBigMotorFloor) / 255) : 0;
+    }
+
+    void CloseDevice()
+    {
+        if (gDev != nullptr)
+        {
+            CloseHandle(gDev);
+            gDev = nullptr;
+        }
+    }
+
+    bool EnsureDevice()
+    {
+        std::wstring path;
+        const int mode = PressureInputs::Ds3DeviceMode(path);
+        if (mode < 0)
+        {
+            CloseDevice();
+            return false;
+        }
+        if (gDev != nullptr && mode == gMode)
+        {
+            return true;
+        }
+        CloseDevice();
+        gMode = mode;
+        if (mode == 2)
+        {
+            static bool warned = false;
+            if (!warned)
+            {
+                warned = true;
+                spdlog::warn("DS3 Rumble - the native report mode has no rumble path; use DsHidMini SDF or SXS.");
+            }
+            return false;
+        }
+
+        gDev = CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+        if (gDev == INVALID_HANDLE_VALUE)
+        {
+            gDev = nullptr;
+            return false;
+        }
+
+        // Windows wants full-length writes, so use the driver's fixed report sizes.
+        PHIDP_PREPARSED_DATA pp = nullptr;
+        HIDP_CAPS caps {};
+        USHORT length = 0;
+        if (HidD_GetPreparsedData(gDev, &pp))
+        {
+            if (HidP_GetCaps(pp, &caps) == HIDP_STATUS_SUCCESS && caps.OutputReportByteLength <= 64)
+            {
+                length = caps.OutputReportByteLength;
+            }
+            HidD_FreePreparsedData(pp);
+        }
+        gReportLen = length ? length : (mode == 0 ? 49 : 19);
+        spdlog::info("DS3 Rumble - write handle open, {} mode, {}-byte output reports.",
+            mode == 0 ? "SXS" : "SDF", gReportLen);
+        return true;
+    }
+
+    bool WriteReport(const uint8_t* src, size_t n)
+    {
+        uint8_t buf[64] {};
+        memcpy(buf, src, n);
+        DWORD wrote = 0;
+        return WriteFile(gDev, buf, gReportLen, &wrote, nullptr) && wrote == gReportLen;
+    }
+
+    // SDF speaks the standard force-feedback protocol: one constant force per motor.
+    bool SendSdf(uint8_t smallMotor, uint8_t bigMotor)
+    {
+        if (smallMotor == 0 && bigMotor == 0)
+        {
+            const uint8_t stop[2] = { 0x19, 0x03 };
+            return WriteReport(stop, sizeof(stop));
+        }
+        const auto lg = static_cast<uint16_t>(BigMotorCurve(bigMotor) * 10000 / 255);
+        const uint8_t left[4] = { 0x14, 0x01, static_cast<uint8_t>(lg & 0xFF), static_cast<uint8_t>(lg >> 8) };
+        const uint16_t sm = smallMotor ? 10000 : 0;
+        const uint8_t right[4] = { 0x14, 0x02, static_cast<uint8_t>(sm & 0xFF), static_cast<uint8_t>(sm >> 8) };
+        const uint8_t start[4] = { 0x18, 0x01, 0x01, 0x01 };
+        return WriteReport(left, sizeof(left)) && WriteReport(right, sizeof(right)) &&
+               WriteReport(start, sizeof(start));
+    }
+
+    // SXS takes the raw 49-byte sixaxis.sys packet; it owns the LED too, so that rides along.
+    bool SendSxs(uint8_t smallMotor, uint8_t bigMotor)
+    {
+        uint8_t r[49] {};
+        r[1] = 0x02;
+        r[5] = 0xFF;
+        r[6] = smallMotor ? 0x01 : 0x00;
+        r[7] = 0xFF;
+        r[8] = BigMotorCurve(bigMotor);
+        r[13] = 0x02;
+        constexpr uint8_t led[5] = { 0xFF, 0x27, 0x10, 0x00, 0x32 };
+        for (int i = 0; i < 4; ++i)
+        {
+            memcpy(&r[14 + 5 * i], led, sizeof(led));
+        }
+        return WriteReport(r, sizeof(r));
+    }
+
+    // The pad holds its last state, so only changes are sent.
+    DWORD WINAPI WriterThread(LPVOID)
+    {
+        uint16_t lastSent = 0;
+        for (;;)
+        {
+            WaitForSingleObject(gWake, 1000);
+            const uint16_t want = gMotors.load(std::memory_order_relaxed);
+            if (want == lastSent)
+            {
+                continue;
+            }
+            if (!EnsureDevice())
+            {
+                continue;
+            }
+            const auto smallMotor = static_cast<uint8_t>(want >> 8);
+            const auto bigMotor = static_cast<uint8_t>(want & 0xFF);
+            if (gMode == 0 ? SendSxs(smallMotor, bigMotor) : SendSdf(smallMotor, bigMotor))
+            {
+                lastSent = want;
+            }
+            else
+            {
+                CloseDevice();
+            }
+        }
+    }
+
+    void Publish(uint16_t state)
+    {
+        if (gMotors.exchange(state, std::memory_order_relaxed) != state)
+        {
+            SetEvent(gWake);
+        }
+    }
+}
+
+
+namespace
+{
+    SafetyHookInline gSetStateHook {};
+
+    // XInput names its motors by frequency: the left is the heavy one, the right the buzz.
+    DWORD WINAPI HookedXInputSetState(DWORD user, XINPUT_VIBRATION* vibration)
+    {
+        if (user == 0 && vibration != nullptr && PressureInputs::HavePad())
+        {
+            // "small" is a Windows macro, so the motors are named for what they do instead.
+            const auto heavy = static_cast<uint8_t>(vibration->wLeftMotorSpeed >> 8);
+            const auto buzz = static_cast<uint8_t>(vibration->wRightMotorSpeed >> 8);
+            Publish(static_cast<uint16_t>((buzz << 8) | heavy));
+        }
+        return gSetStateHook.stdcall<DWORD>(user, vibration);
+    }
+}
+
+void Ds3Rumble::Shutdown()
+{
+    // Quitting mid-rumble buzzes forever unless the exit path sends one silence.
+    Publish(0);
+    if (gDev != nullptr)
+    {
+        if (gMode == 0) { SendSxs(0, 0); } else { SendSdf(0, 0); }
+        CloseDevice();
+    }
+}
+
+void Ds3Rumble::Initialize()
+{
+    if (!bEnabled || !(eGameType & MGS4))
+    {
+        return;
+    }
+    if (!PressureInputs::bEnabled)
+    {
+        spdlog::info("DS3 Rumble - needs Dualshock 3 Controller Support to be on.");
+        return;
+    }
+
+    gWake = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (gWake == nullptr)
+    {
+        return;
+    }
+
+    // XInput is imported by ordinal; 3 is XInputSetState, which carries the motor values.
+    const HMODULE xinput = GetModuleHandleA("XINPUT1_4.dll");
+    if (xinput == nullptr)
+    {
+        spdlog::warn("DS3 Rumble - XINPUT1_4.dll is not loaded; no rumble.");
+        return;
+    }
+    auto* setState = reinterpret_cast<void*>(GetProcAddress(xinput, MAKEINTRESOURCEA(3)));
+    if (setState == nullptr)
+    {
+        spdlog::warn("DS3 Rumble - XInputSetState was not found.");
+        return;
+    }
+
+    gSetStateHook = safetyhook::create_inline(setState, reinterpret_cast<void*>(HookedXInputSetState));
+    LOG_HOOK(gSetStateHook, "MGS 4: DS3 Rumble - XInputSetState")
+    if (!gSetStateHook)
+    {
+        return;
+    }
+
+    if (HANDLE thread = CreateThread(nullptr, 0, WriterThread, nullptr, 0, nullptr))
+    {
+        CloseHandle(thread);
+    }
+}

--- a/src/fixes/ds3_rumble.hpp
+++ b/src/fixes/ds3_rumble.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Ds3Rumble
+{
+    inline bool bEnabled = true;
+    inline int iStrength = 100;     // big-motor scale, percent
+
+    void Initialize();
+    void Shutdown();
+}

--- a/src/fixes/pad_motion.cpp
+++ b/src/fixes/pad_motion.cpp
@@ -1,0 +1,194 @@
+#include "stdafx.h"
+#include "pad_motion.hpp"
+#include "pressure_inputs.hpp"
+
+#include "common.hpp"
+#include "helper.hpp"
+#include "logging.hpp"
+
+#include <algorithm>
+#include <atomic>
+
+namespace
+{
+    struct MotionData
+    {
+        float rotQuatX, rotQuatY, rotQuatZ, rotQuatW;
+        float posAccelX, posAccelY, posAccelZ;
+        float rotVelX, rotVelY, rotVelZ;
+    };
+
+    // Steam reports 16384 counts per g, so scale the pad's counts to match.
+    constexpr float kStepsPerG = 16384.0f;
+    constexpr float kLimit = 32767.0f;
+
+    // The DualShock 3 and the DualSense disagree on which way up z is.
+    constexpr float kAxisSign[3] { 1.0f, 1.0f, -1.0f };
+
+    // The game only looks for a shake if it thinks it is holding a PlayStation pad.
+    constexpr int kPlayStationPad = 2;
+
+    constexpr size_t kGetMotionData = 29;    // ISteamInput006
+
+    SafetyHookInline gMotionHook {};
+    SafetyHookMid gDecideHook {};
+    void* gInput = nullptr;
+    void** gVtable = nullptr;
+    bool gGaveUp = false;
+    std::atomic<bool> gSaidSo = false;
+
+    // Zero means read the motion from the accelerometer, anything else from the orientation.
+    uint8_t* gFromQuaternion = nullptr;
+
+    bool Empty(const MotionData& m)
+    {
+        return m.posAccelX == 0.0f && m.posAccelY == 0.0f && m.posAccelZ == 0.0f;
+    }
+
+    void* HookedGetMotionData(void* self, void* into, uint64_t input)
+    {
+        void* result = gMotionHook.stdcall<void*>(self, into, input);
+        if (!PadMotion::bEnabled || !Memory::IsWritable(into, sizeof(MotionData)))
+        {
+            return result;
+        }
+        auto& m = *static_cast<MotionData*>(into);
+
+        int axis[3] {};
+        if (!Empty(m) || !PressureInputs::RawMotion(axis))
+        {
+            return result;
+        }
+
+        const float scale = kStepsPerG / static_cast<float>(PressureInputs::MotionCountsPerG());
+        for (int i = 0; i < 3; i++)
+        {
+            (&m.posAccelX)[i] = std::clamp(static_cast<float>(axis[i]) * scale * kAxisSign[i],
+                -kLimit, kLimit);
+        }
+
+        m.rotQuatX = m.rotQuatY = m.rotQuatZ = 0.0f;
+        m.rotQuatW = 1.0f;
+        m.rotVelX = m.rotVelY = m.rotVelZ = 0.0f;
+
+        // The orientation loses how hard the pad was shaken, so force the accelerometer path.
+        if (gFromQuaternion != nullptr)
+        {
+            *gFromQuaternion = 0;
+        }
+
+        if (!gSaidSo.exchange(true))
+        {
+            spdlog::info("MGS 4: Pad Motion - feeding the pad's accelerometer to the game, "
+                "{} counts to the g scaled to {}.", PressureInputs::MotionCountsPerG(),
+                static_cast<int>(kStepsPerG));
+        }
+        return result;
+    }
+
+    // The game re-decides the pad type on every input, so answer where that decision is made.
+    void HookTypeDecision()
+    {
+        constexpr ptrdiff_t kCompare = 12;      // the cmp eax,ecx the pattern ends on
+
+        if (uint8_t* at = Memory::PatternScanUnique(baseModule,
+            "8B 0D ?? ?? ?? ?? 8B 15 ?? ?? ?? ?? 3B C1 75 08 39 15",
+            "MGS 4: Pad Motion - controller type | where the game decides it"))
+        {
+            gDecideHook = safetyhook::create_mid(at + kCompare, [](SafetyHookContext& ctx)
+            {
+                if (PressureInputs::HavePad())
+                {
+                    ctx.rcx = kPlayStationPad;
+                }
+            });
+            LOG_HOOK(gDecideHook, "MGS 4: Pad Motion - controller type")
+        }
+    }
+
+    void Hook()
+    {
+        const HMODULE steam = GetModuleHandleA("steam_api64.dll");
+        if (steam == nullptr)
+        {
+            return;
+        }
+        using UserFn = int (*)();
+        using FindFn = void* (*)(int, const char*);
+        auto* user = reinterpret_cast<UserFn>(GetProcAddress(steam, "SteamAPI_GetHSteamUser"));
+        auto* find = reinterpret_cast<FindFn>(
+            GetProcAddress(steam, "SteamInternal_FindOrCreateUserInterface"));
+        if (user == nullptr || find == nullptr)
+        {
+            return;
+        }
+        gInput = find(user(), "SteamInput006");
+        if (gInput == nullptr || !Memory::IsReadable(gInput, sizeof(void*)))
+        {
+            return;
+        }
+        gVtable = *reinterpret_cast<void***>(gInput);
+
+        if (!Memory::IsExecutable(gVtable[kGetMotionData]))
+        {
+            spdlog::warn("MGS 4: Pad Motion - Steam Input's table does not look like code; "
+                "leaving it alone.");
+            gGaveUp = true;
+            gVtable = nullptr;
+            return;
+        }
+        gMotionHook = safetyhook::create_inline(gVtable[kGetMotionData],
+            reinterpret_cast<void*>(HookedGetMotionData));
+        LOG_HOOK(gMotionHook, "MGS 4: Pad Motion - ISteamInput::GetMotionData")
+
+        if (uint8_t* test = Memory::PatternScanUnique(baseModule,
+            "48 8B 43 10 48 89 43 18 48 8B 43 08 48 89 43 10 48 8B 03 48 89 43 08 80 3D ?? ?? ?? ?? ??",
+            "MGS 4: Pad Motion - Sixaxis source | accelerometer or orientation"))
+        {
+            // cmp byte ptr [rip+disp32], imm8 - 7 bytes long, displacement 2 in.
+            constexpr ptrdiff_t kCmp = 23;      // cmp byte ptr [rip+disp32], imm8
+            auto* flag = reinterpret_cast<uint8_t*>(Memory::GetRipRelativeAddress(test + kCmp, 2, 7));
+
+            // The byte is a selector, so it holds 0 or 1. Anything else is not the byte we resolved
+            // for and is not worth writing to.
+            if (Memory::IsWritable(flag, sizeof(uint8_t)) && *flag <= 1)
+            {
+                gFromQuaternion = flag;
+            }
+            else
+            {
+                spdlog::warn("MGS 4: Pad Motion - the Sixaxis source byte resolved to {:s}+{:X}, "
+                    "which is not writable; leaving it alone.", sExeName.c_str(),
+                    reinterpret_cast<uintptr_t>(flag) - reinterpret_cast<uintptr_t>(baseModule));
+            }
+        }
+        HookTypeDecision();
+    }
+
+    DWORD WINAPI WaitThread(LPVOID)
+    {
+        for (int tries = 0; tries < 60 && gVtable == nullptr && !gGaveUp; ++tries)
+        {
+            Sleep(1000);
+            Hook();
+        }
+        if (gVtable == nullptr && !gGaveUp)
+        {
+            spdlog::info("MGS 4: Pad Motion - Steam Input never appeared; the pad's motion has "
+                "nowhere to go.");
+        }
+        return 0;
+    }
+}
+
+void PadMotion::Initialize()
+{
+    if (!bEnabled || !(eGameType & MGS4) || !PressureInputs::bEnabled)
+    {
+        return;
+    }
+    if (HANDLE thread = CreateThread(nullptr, 0, WaitThread, nullptr, 0, nullptr))
+    {
+        CloseHandle(thread);
+    }
+}

--- a/src/fixes/pad_motion.cpp
+++ b/src/fixes/pad_motion.cpp
@@ -142,10 +142,9 @@ namespace
         LOG_HOOK(gMotionHook, "MGS 4: Pad Motion - ISteamInput::GetMotionData")
 
         if (uint8_t* test = Memory::PatternScanUnique(baseModule,
-            "48 8B 43 10 48 89 43 18 48 8B 43 08 48 89 43 10 48 8B 03 48 89 43 08 80 3D ?? ?? ?? ?? ??",
+            "48 8B 43 10 48 89 43 18 48 8B 43 08 48 89 43 10 48 8B 03 48 89 43 08 80 3D",
             "MGS 4: Pad Motion - Sixaxis source | accelerometer or orientation"))
         {
-            // cmp byte ptr [rip+disp32], imm8 - 7 bytes long, displacement 2 in.
             constexpr ptrdiff_t kCmp = 23;      // cmp byte ptr [rip+disp32], imm8
             auto* flag = reinterpret_cast<uint8_t*>(Memory::GetRipRelativeAddress(test + kCmp, 2, 7));
 

--- a/src/fixes/pad_motion.hpp
+++ b/src/fixes/pad_motion.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+
+// Shaking the pad resets the OctoCamo. The game gets pad motion from Steam, which has none for a
+// DualShock 3, so we answer that call with the pad's accelerometer instead.
+namespace PadMotion
+{
+    inline bool bEnabled = true;
+
+    void Initialize();
+}

--- a/src/fixes/pressure_inputs.cpp
+++ b/src/fixes/pressure_inputs.cpp
@@ -1,0 +1,560 @@
+#include "stdafx.h"
+#include "pressure_inputs.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+#include <atomic>
+#include <cmath>
+#include <mutex>
+#include <hidsdi.h>
+#pragma comment(lib, "hid.lib")
+
+// libgv's pad converter flattens GV_PAD.pressure[12] to 0xFF/0x00 for every pad it reads, passing
+// only the analogue triggers through. Refill it from a DualShock 3, via DsHidMini in SDF or SXS mode.
+namespace
+{
+    constexpr size_t kSlots = 12;
+    constexpr size_t kCircle = 5;
+    constexpr size_t kTriangle = 4;
+    constexpr size_t kL1 = 8;           // libgv.h PAD_PRESS_L1
+    constexpr size_t kR1 = 9;           // libgv.h PAD_PRESS_R1
+    constexpr size_t kL2 = 10;          // libgv.h PAD_PRESS_L2
+    constexpr size_t kR2 = 11;          // libgv.h PAD_PRESS_R2
+    constexpr size_t kSquare = 7;
+
+    // Where each of our slots (R L U D TRI CIR CRO SQU L1 R1 L2 R2) sits in the pad's report.
+    constexpr int kSdfOrder[kSlots] = { 3, 5, 2, 4, 8, 9, 10, 11, 6, 7, 0, 1 };
+    constexpr int kNativeOrder[kSlots] = { 1, 3, 0, 2, 8, 9, 10, 11, 6, 7, 4, 5 };
+
+    constexpr size_t kNone = static_cast<size_t>(-1);
+
+    struct Profile
+    {
+        const char* name;
+        bool feature;           // poll HidD_GetFeature rather than read input reports
+        size_t length;
+        size_t base;            // first pressure byte
+        const int* order;
+        size_t accel;           // first accelerometer byte, kNone in a report too short to carry one
+        int accelCentre;        // ten unsigned bits, so rest sits around the middle of the range
+        int countsPerG;         // what the accelerometer calls one g; no two pads agree on it
+    };
+
+    // Three little-endian accelerometer values centred on 512. SDF's report is too short for them.
+    constexpr Profile kProfiles[] = {
+        { "SXS",    true,  50, 15, kNativeOrder, 42,    512, 115 },
+        { "SDF",    false, 39,  8, kSdfOrder,    kNone, 512, 115 },
+        { "native", false, 49, 14, kNativeOrder, 41,    512, 115 },
+    };
+    const Profile* gProfile = nullptr;
+
+    void NoteMotion(const uint8_t* report);   // defined with the shake handling further down
+
+    std::atomic<bool> gHavePad = false;
+    std::atomic<uint8_t> gCirclePressure = 0;
+    uint8_t gPressure[kSlots] {};
+    std::mutex gPressureLock;
+
+    // The open device's path and kProfiles index, for rumble's own write handle.
+    std::wstring gDevicePath;
+    int gDeviceMode = -1;
+
+    void PublishDevice(const std::wstring& path, int mode)
+    {
+        const std::lock_guard<std::mutex> guard(gPressureLock);
+        gDevicePath = path;
+        gDeviceMode = mode;
+    }
+
+    constexpr DWORD kReadGone = ~0u;    // disconnected, as opposed to merely quiet
+
+    constexpr DWORD kRetryFirst = 2000;
+    constexpr DWORD kRetryMax = 16000;
+
+    // Overlapped: a silent interface must not wedge discovery or the reader.
+    DWORD ReadReport(HANDLE h, HANDLE ev, uint8_t* buf, DWORD len, DWORD timeoutMs)
+    {
+        OVERLAPPED ov {};
+        ov.hEvent = ev;
+        ResetEvent(ev);
+
+        if (!ReadFile(h, buf, len, nullptr, &ov) && GetLastError() != ERROR_IO_PENDING)
+        {
+            return kReadGone;
+        }
+        if (WaitForSingleObject(ev, timeoutMs) != WAIT_OBJECT_0)
+        {
+            CancelIo(h);
+            WaitForSingleObject(ev, 200);
+            return 0;
+        }
+
+        DWORD read = 0;
+        return GetOverlappedResult(h, &ov, &read, FALSE) ? read : kReadGone;
+    }
+
+    // DsHidMini stamps 00 3F over the first two bytes of the feature report. That pair is SXS.
+    bool ReadFeature(HANDLE h, uint8_t* buf, size_t len)
+    {
+        memset(buf, 0, len);
+        return HidD_GetFeature(h, buf, static_cast<ULONG>(len)) != FALSE;
+    }
+
+    // Match on exact length: a 49-byte report would otherwise parse as SDF at the wrong offsets.
+    const Profile* ProbeInputProfile(HANDLE h)
+    {
+        uint8_t buf[96];
+        HANDLE ev = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (ev == nullptr)
+        {
+            return nullptr;
+        }
+        const DWORD read = ReadReport(h, ev, buf, sizeof(buf), 500);
+        CloseHandle(ev);
+
+        for (const Profile& p : kProfiles)
+        {
+            if (!p.feature && read == p.length && buf[0] == 0x01)
+            {
+                return &p;
+            }
+        }
+        return nullptr;
+    }
+
+    // Steam Input hides the pad from SetupDi, so take the interface paths from the registry.
+    HANDLE OpenDs3()
+    {
+        GUID hid {};
+        HidD_GetHidGuid(&hid);
+
+        wchar_t guid[40];
+        swprintf_s(guid, L"{%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}",
+            hid.Data1, hid.Data2, hid.Data3, hid.Data4[0], hid.Data4[1], hid.Data4[2],
+            hid.Data4[3], hid.Data4[4], hid.Data4[5], hid.Data4[6], hid.Data4[7]);
+
+        HKEY cls = nullptr;
+        const std::wstring devices =
+            L"SYSTEM\\CurrentControlSet\\Control\\DeviceClasses\\" + std::wstring(guid);
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, devices.c_str(), 0, KEY_READ, &cls) != ERROR_SUCCESS)
+        {
+            return nullptr;
+        }
+
+        HANDLE found = nullptr;
+        size_t candidates = 0;
+        DWORD lastError = 0;
+        wchar_t name[512];
+        for (DWORD i = 0; found == nullptr; ++i)
+        {
+            DWORD len = static_cast<DWORD>(std::size(name));
+            if (RegEnumKeyExW(cls, i, name, &len, nullptr, nullptr, nullptr, nullptr) != ERROR_SUCCESS)
+            {
+                break;
+            }
+            std::wstring key = name;
+            std::wstring lower = key;
+            std::transform(lower.begin(), lower.end(), lower.begin(), ::towlower);
+            if (lower.find(L"vid_054c") == std::wstring::npos
+                || lower.find(L"pid_0268") == std::wstring::npos
+                || lower.rfind(L"##?#", 0) != 0
+                || lower.find(L"ig_00") != std::wstring::npos)   // XInput node, no pressure
+            {
+                continue;
+            }
+            ++candidates;
+            // the registry spells the symbolic link with '#' for the leading separators only.
+            const std::wstring path = L"\\\\?\\" + key.substr(4);
+            HANDLE h = CreateFileW(path.c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+            if (h == INVALID_HANDLE_VALUE)
+            {
+                lastError = GetLastError();     // 2 = stale entry, 5 = something is hiding it
+                continue;
+            }
+
+            uint8_t probe[96] {};
+            if (ReadFeature(h, probe, sizeof(probe)) && probe[1] == 0x00 && probe[2] == 0x3F)
+            {
+                found = h;
+                gProfile = &kProfiles[0];
+                PublishDevice(path, 0);
+                continue;
+            }
+
+            // SDF and native need input reports, so reopen for read.
+            CloseHandle(h);
+            h = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                nullptr, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, nullptr);
+            if (h == INVALID_HANDLE_VALUE)
+            {
+                lastError = GetLastError();
+                continue;
+            }
+            // A dead node would block the reader and hide a working pad behind it.
+            if (const Profile* profile = ProbeInputProfile(h))
+            {
+                found = h;
+                gProfile = profile;
+                PublishDevice(path, static_cast<int>(profile - kProfiles));
+            }
+            else
+            {
+                CloseHandle(h);
+            }
+        }
+        RegCloseKey(cls);
+
+        static bool reported = false;
+        if (found == nullptr && !reported)
+        {
+            reported = true;
+            if (candidates == 0)
+            {
+                spdlog::info("Pressure Inputs - No DualShock 3 registered.");
+            }
+            else if (lastError == ERROR_ACCESS_DENIED)
+            {
+                spdlog::warn("Pressure Inputs - {} DualShock 3 interface(s) found but access was "
+                    "denied. HidHide must allow the game.", candidates);
+            }
+            else
+            {
+                spdlog::warn("Pressure Inputs - {} DualShock 3 interface(s) found, none reporting "
+                    "pressure. DsHidMini must be in SDF or SXS mode.", candidates);
+            }
+        }
+        return found;
+    }
+
+    DWORD WINAPI ReaderThread(LPVOID)
+    {
+        uint8_t report[96];
+        HANDLE pad = nullptr;
+        DWORD retry = kRetryFirst;
+        HANDLE ev = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        for (;;)
+        {
+            if (pad == nullptr)
+            {
+                pad = OpenDs3();
+                if (pad == nullptr)
+                {
+                    gHavePad = false;
+                    Sleep(retry);
+                    retry = std::min<DWORD>(retry * 2, kRetryMax);
+                    continue;
+                }
+                retry = kRetryFirst;
+                spdlog::info("Pressure Inputs - DualShock 3 opened, {} mode, {}-byte reports.",
+                    gProfile->name, gProfile->length);
+            }
+
+            bool lost = false;
+            if (gProfile->feature)
+            {
+                // Synchronous IOCTL, so keep it off the render thread and poll once a frame.
+                lost = !ReadFeature(pad, report, gProfile->length);
+                if (!lost)
+                {
+                    Sleep(8);
+                }
+            }
+            else
+            {
+                const DWORD read = ReadReport(pad, ev, report, sizeof(report), 5000);
+                if (read == 0)
+                {
+                    continue;      // quiet pad, not a lost one
+                }
+                lost = read == kReadGone || read < gProfile->length;
+            }
+
+            if (lost)
+            {
+                CloseHandle(pad);
+                pad = nullptr;
+                gProfile = nullptr;
+                gHavePad = false;
+                PublishDevice({}, -1);
+                Sleep(retry);
+                retry = std::min<DWORD>(retry * 2, kRetryMax);
+                continue;
+            }
+
+            NoteMotion(report);
+
+            const std::lock_guard<std::mutex> guard(gPressureLock);
+            for (size_t s = 0; s < kSlots; ++s)
+            {
+                gPressure[s] = report[gProfile->base + gProfile->order[s]];
+            }
+            gCirclePressure = gPressure[kCircle];
+            gHavePad = true;
+        }
+    }
+
+    // ---- the pad's motion ---------------------------------------------------------------------
+    // Keep the latest accelerometer reading. pad_motion.cpp hands it to the game, which finds the
+    // shake itself.
+    std::atomic<int> gMotion[3] {};
+    std::atomic<bool> gHaveMotion = false;
+
+    void NoteMotion(const uint8_t* report)
+    {
+        if (gProfile == nullptr || gProfile->accel == kNone)
+        {
+            return;
+        }
+        const size_t at = gProfile->accel;
+        if (at + 6 > gProfile->length)
+        {
+            return;
+        }
+        for (int i = 0; i < 3; i++)
+        {
+            const int low = report[at + i * 2];
+            const int high = report[at + i * 2 + 1];
+            gMotion[i] = (low | (high << 8)) - gProfile->accelCentre;
+        }
+        gHaveMotion = true;
+    }
+
+    void ReadPad(uint8_t (&out)[kSlots])
+    {
+        const std::lock_guard<std::mutex> guard(gPressureLock);
+        memcpy(out, gPressure, sizeof(out));
+    }
+
+
+    // ---- MGS 4 ------------------------------------------------------------------------------
+    // Every pad reader in the game works from copies of one buffer entry, so filling that entry in
+    // covers all of them. Entry layout: sticks at 4, twelve pressure values at 8, motion at 0x14.
+    constexpr size_t kUp = 2;                   // libgv.h PAD_PRESS_U
+    constexpr size_t kEntrySize = 0x2C;
+    constexpr size_t kEntryPressure = 0x08;
+    constexpr size_t kPadsPerRing = 4;          // entries interleave as (slot + sample * 4) * 0x2C
+
+    uintptr_t gRingBase = 0;                    // the raw pad ring, so only pad slot 0 is fed
+    const float* gDemoZoomMax = nullptr;        // the clamp the cutscene zoom uses (2.0 as shipped)
+    std::atomic<bool> gFedOnce = false;
+
+    // Nothing is written unless the entry is demonstrably one of the ring's, so a hook that landed
+    // somewhere unexpected writes nowhere rather than over whatever rdi happened to hold.
+    void FeedEntry(uintptr_t entry)
+    {
+        if (entry == 0 || gRingBase == 0 || entry < gRingBase)
+        {
+            return;
+        }
+
+        const uintptr_t into = entry - gRingBase;
+        if (into % kEntrySize != 0 || (into / kEntrySize) % kPadsPerRing != 0)
+        {
+            return;
+        }
+
+        if (!Memory::IsWritable(reinterpret_cast<void*>(entry + kEntryPressure), kSlots))
+        {
+            return;
+        }
+
+        if (!gHavePad.load())
+        {
+            return;         // no pressure to feed, but the entry above was still worth reading
+        }
+        uint8_t now[kSlots];
+        ReadPad(now);
+
+        memcpy(reinterpret_cast<void*>(entry + kEntryPressure), now, kSlots);
+
+        if (!gFedOnce.exchange(true))
+        {
+            spdlog::info("MGS 4: Pressure Inputs - Feeding DualShock 3 pressure into pad slot 0.");
+        }
+    }
+
+    // The port zooms cutscenes by a fixed step. On PS3 how hard you pressed was the amount.
+    float DemoZoomTarget(uint8_t up)
+    {
+        const float max = (gDemoZoomMax != nullptr) ? *gDemoZoomMax : 2.0f;
+        return 1.0f + (max - 1.0f) * (static_cast<float>(up) / 255.0f);
+    }
+
+    void InitializeMGS4()
+    {
+        // The raw ring's base, from the lea that indexes it right before the converter call.
+        if (uint8_t* address = Memory::PatternScanUnique(baseModule,
+            "48 6B C9 2C F2 0F 11 84 24 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 8B D3 48 03 C8",
+            "MGS 4: Pressure Inputs - Pad Ring | GV_PAD thread -> converter call"))
+        {
+            constexpr ptrdiff_t kLea = 13;      // lea rax,[ring]
+            const uintptr_t ring = Memory::GetRipRelativeAddress(address + kLea, 3, 7);
+            if (!Memory::IsReadable(reinterpret_cast<const void*>(ring), sizeof(void*)))
+            {
+                spdlog::error("MGS 4: Pressure Inputs - the pad ring resolved to {:s}+{:X}, which is "
+                    "not there; leaving the ring alone.", sExeName.c_str(),
+                    ring - reinterpret_cast<uintptr_t>(baseModule));
+            }
+            else
+            {
+                gRingBase = ring;
+                if (g_Logging.bVerboseLogging)
+                {
+                    spdlog::info("MGS 4: Pressure Inputs - pad ring at {:s}+{:X}", sExeName.c_str(),
+                        gRingBase - reinterpret_cast<uintptr_t>(baseModule));
+                }
+            }
+        }
+
+        constexpr ptrdiff_t kAfterR2 = 3;       // just past the mov [rdi+13h],al that stores R2
+
+        if (uint8_t* address = Memory::PatternScanUnique(baseModule,
+            "88 47 13 0F 29 74 24 40 4C 8B 74 24 78",
+            "MGS 4: Pressure Inputs - Pad Writer | GV_PAD thread -> XINPUT_STATE to PADBUF"))
+        {
+            static SafetyHookMid writerHook {};
+            writerHook = safetyhook::create_mid(address + kAfterR2, [](SafetyHookContext& ctx)
+            {
+                FeedEntry(ctx.rdi);
+            });
+            LOG_HOOK(writerHook, "MGS 4: Pressure Inputs - Pad Writer")
+        }
+
+        // The game ignores pressure unless the controls are bound its way. Answer both of its
+        // checks so the pad's real values get used.
+        constexpr ptrdiff_t kTypeCheck = 0x16;  // the dec eax on the controller type
+
+        if (uint8_t* address = Memory::PatternScanUnique(baseModule,
+            "48 83 EC 28 8D 81 00 FF FF FF A9 FF FE FF FF 75 ?? E8 ?? ?? ?? ?? FF C8 83 F8 06 77",
+            "MGS 4: Pressure Inputs - Firm Press Gate | analogue-trigger binding test"))
+        {
+            static SafetyHookMid gateBindingHook {};
+            gateBindingHook = safetyhook::create_mid(address, [](SafetyHookContext& ctx)
+            {
+                if (gHavePad.load())
+                {
+                    ctx.rcx = 0x200;
+                }
+            });
+            LOG_HOOK(gateBindingHook, "MGS 4: Pressure Inputs - Firm Press Gate | binding test")
+
+            static SafetyHookMid gateTypeHook {};
+            gateTypeHook = safetyhook::create_mid(address + kTypeCheck, [](SafetyHookContext& ctx)
+            {
+                if (gHavePad.load())
+                {
+                    ctx.rax = 0x7F;    // past the switch, straight to "true"
+                }
+            });
+            LOG_HOOK(gateTypeHook, "MGS 4: Pressure Inputs - Firm Press Gate | controller type test")
+        }
+
+        if (uint8_t* address = Memory::PatternScanUnique(baseModule,
+            "F3 0F 10 1D ?? ?? ?? ?? 0F 2F C3 73 0D 41 0F 2F C6",
+            "MGS 4: Pressure Inputs - Cutscene Zoom Clamp | demo input"))
+        {
+            const auto* max = reinterpret_cast<const float*>(Memory::GetRipRelativeAddress(address, 4, 8));
+            if (Memory::IsReadable(max, sizeof(float)))
+            {
+                gDemoZoomMax = max;
+            }
+            else
+            {
+                spdlog::warn("MGS 4: Pressure Inputs - the zoom clamp did not resolve to anything "
+                    "readable; falling back to the built-in maximum.");
+            }
+        }
+
+        // Where the zoom target is stored: replace the fixed step with how hard UP is pressed.
+        constexpr ptrdiff_t kZoomStore = 8;     // the movss [rbx+0D8h],xmm6 that stores the target
+
+        if (uint8_t* address = Memory::PatternScanUnique(baseModule,
+            "F3 0F 58 B3 D8 00 00 00 F3 0F 11 B3 D8 00 00 00 EB",
+            "MGS 4: Pressure Inputs - Cutscene Zoom | demo input -> CinematicZoomIn"))
+        {
+            static SafetyHookMid zoomHook {};
+            zoomHook = safetyhook::create_mid(address + kZoomStore, [](SafetyHookContext& ctx)
+            {
+                if (!gHavePad.load())
+                {
+                    return;
+                }
+                uint8_t now[kSlots];
+                ReadPad(now);
+                if (now[kUp] == 0)
+                {
+                    return;
+                }
+                ctx.xmm6.f32[0] = DemoZoomTarget(now[kUp]);
+            });
+            LOG_HOOK(zoomHook, "MGS 4: Pressure Inputs - Cutscene Zoom")
+        }
+    }
+}
+
+void PressureInputs::ReadPad(uint8_t (&out)[kPadSlots])
+{
+    static_assert(kPadSlots == kSlots, "pad slot count out of step with libgv");
+    const std::lock_guard<std::mutex> guard(gPressureLock);
+    memcpy(out, gPressure, sizeof(out));
+}
+
+bool PressureInputs::RawMotion(int (&axis)[3])
+{
+    if (!gHaveMotion.load())
+    {
+        return false;
+    }
+    for (int i = 0; i < 3; i++)
+    {
+        axis[i] = gMotion[i].load();
+    }
+    return true;
+}
+
+int PressureInputs::MotionCountsPerG()
+{
+    const Profile* profile = gProfile;
+    return profile != nullptr ? profile->countsPerG : 113;
+}
+
+bool PressureInputs::HavePad()
+{
+    return gHavePad.load();
+}
+
+int PressureInputs::Ds3DeviceMode(std::wstring& path)
+{
+    if (!gHavePad.load())
+    {
+        return -1;
+    }
+    const std::lock_guard<std::mutex> guard(gPressureLock);
+    if (gDeviceMode < 0)
+    {
+        return -1;
+    }
+    path = gDevicePath;
+    return gDeviceMode;
+}
+
+void PressureInputs::Initialize()
+{
+    if (!bEnabled)
+    {
+        return;
+    }
+    if (!(eGameType & MGS4))
+    {
+        return;
+    }
+
+    InitializeMGS4();
+
+    if (HANDLE reader = CreateThread(nullptr, 0, ReaderThread, nullptr, 0, nullptr))
+    {
+        CloseHandle(reader);
+    }
+}

--- a/src/fixes/pressure_inputs.hpp
+++ b/src/fixes/pressure_inputs.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+
+namespace PressureInputs
+{
+    inline bool bEnabled = false;
+
+    void Initialize();
+
+    // Last accelerometer reading, centred on rest, and what one g is worth in the pad's counts.
+    bool RawMotion(int (&axis)[3]);
+    int MotionCountsPerG();
+
+
+    // Twelve slots, libgv order: R L U D TRI CIR CRO SQU L1 R1 L2 R2. Zeroed without a pad.
+    constexpr size_t kPadSlots = 12;
+    void ReadPad(uint8_t (&out)[kPadSlots]);
+
+    // The open DsHidMini device, for rumble to open its own write handle: fills path and
+    // returns the mode (0 SXS, 1 SDF, 2 native), or -1 without a pad.
+    int Ds3DeviceMode(std::wstring& path);
+    bool HavePad();
+}

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include "config.hpp"
+#include "pressure_inputs.hpp"
 
 #include "inipp/inipp.h"
 
@@ -241,6 +242,9 @@ void Config::Read()
     //    LOG_CONFIG(ConfigKeys::ShowSpeedrunnerOverlay_Section, ConfigKeys::ShowSpeedrunnerOverlay_Setting, sSpeedrunnerOverlay);
     //
     //}
+
+    ConfigHelper::getValue(ini, ConfigKeys::Ds3Support_Section, ConfigKeys::Ds3Support_Setting, PressureInputs::bEnabled);
+    LOG_CONFIG(ConfigKeys::Ds3Support_Section, ConfigKeys::Ds3Support_Setting, PressureInputs::bEnabled);
 
     ConfigHelper::getValue(ini, ConfigKeys::SaveFileReadOnlyWarning_Section, ConfigKeys::SaveFileReadOnlyWarning_Setting, CheckGamesaveFolderWritable::bCheckSaveFilesReadOnly);
     LOG_CONFIG(ConfigKeys::SaveFileReadOnlyWarning_Section, ConfigKeys::SaveFileReadOnlyWarning_Setting, CheckGamesaveFolderWritable::bCheckSaveFilesReadOnly);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -36,6 +36,12 @@ namespace ConfigKeys
                                                               "\n"
                                                               "Enabling this forces it to always render at full resolution instead.";
 
+    constexpr const char* Ds3Support_Section = "Controller Settings";
+    constexpr const char* Ds3Support_Setting = "Enable DS3 Support";
+    constexpr const char* Ds3Support_Help = "";
+    constexpr const char* Ds3Support_Tooltip = "Restores pressure controls, rumble and shake for Dualshock 3 controllers.\n"
+                                               "\n"
+                                               "Any pressure supporting button bound will use analog values.";
 
     constexpr const char* Language_Section = "Language Settings";
     constexpr const char* Language_Setting = "Game Language";

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -216,6 +216,12 @@ namespace Memory
             {
 
                 spdlog::info("{}: Pattern scan found. Address: {:s}+{:X}", prefix, sExeName.c_str(), (uintptr_t)foundPattern - (uintptr_t)baseModule);
+
+                const std::vector<std::uint8_t*> everywhere = FindMultiplePatternMatches(module, signature);
+                if (everywhere.size() > 1)
+                {
+                    spdlog::warn("{}: Pattern names {} places, and the first was taken. Narrow it.", prefix, everywhere.size());
+                }
             }
         }
         else
@@ -224,6 +230,78 @@ namespace Memory
             spdlog::error("{}: Pattern scan failed.", prefix);
         }
         return foundPattern;
+    }
+
+    std::uint8_t* PatternScanUnique(void* module, const char* signature, const char* prefix)
+    {
+        auto* dosHeader = reinterpret_cast<PIMAGE_DOS_HEADER>(module);
+        auto* ntHeaders = reinterpret_cast<PIMAGE_NT_HEADERS>(reinterpret_cast<std::uint8_t*>(module) + dosHeader->e_lfanew);
+        const size_t sizeOfImage = ntHeaders->OptionalHeader.SizeOfImage;
+        const std::vector<int> patternBytes = PatternToBytes(signature);
+        auto* scanBytes = reinterpret_cast<std::uint8_t*>(module);
+
+        if (patternBytes.empty() || patternBytes.size() > sizeOfImage)
+        {
+            spdlog::error("{}: Signature is unusable.", prefix);
+            return nullptr;
+        }
+
+        const auto Offset = [](const std::uint8_t* at)
+        {
+            return reinterpret_cast<uintptr_t>(at) - reinterpret_cast<uintptr_t>(baseModule);
+        };
+
+        std::uint8_t* first = nullptr;
+        std::uint8_t* second = nullptr;
+
+        for (size_t i = 0; i + patternBytes.size() <= sizeOfImage; ++i)
+        {
+            bool found = true;
+            for (size_t j = 0; j < patternBytes.size(); ++j)
+            {
+                if (patternBytes[j] != -1 && scanBytes[i + j] != static_cast<std::uint8_t>(patternBytes[j]))
+                {
+                    found = false;
+                    break;
+                }
+            }
+
+            if (!found || !IsExecutable(scanBytes + i))
+            {
+                continue;
+            }
+
+            if (first == nullptr)
+            {
+                first = scanBytes + i;
+                continue;
+            }
+
+            second = scanBytes + i;
+            break;
+        }
+
+        if (first == nullptr)
+        {
+            spdlog::error("{}: Pattern scan failed - the signature names nothing in this build.", prefix);
+            return nullptr;
+        }
+
+        if (second != nullptr)
+        {
+            spdlog::error("{}: Pattern scan refused - the signature names both {:s}+{:X} and {:s}+{:X}, "
+                "so choosing one would be a guess.", prefix,
+                sExeName.c_str(), Offset(first), sExeName.c_str(), Offset(second));
+            return nullptr;
+        }
+
+        if (g_Logging.bVerboseLogging)
+        {
+            spdlog::info("{}: Pattern scan found, and only there. Address: {:s}+{:X}",
+                prefix, sExeName.c_str(), Offset(first));
+        }
+
+        return first;
     }
 
     std::vector<std::uint8_t*> FindMultiplePatternMatches(void* module, const char* signature)

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -22,6 +22,9 @@ namespace Memory
 
     std::uint8_t* PatternScan(void* module, const char* signature, const char* prefix);
 
+    // Like PatternScan, but returns nothing if more than one match.
+    std::uint8_t* PatternScanUnique(void* module, const char* signature, const char* prefix);
+
     std::vector<std::uint8_t*> FindMultiplePatternMatches(void* module, const char* signature);
 
     bool IsReadable(const void* ptr, size_t size);


### PR DESCRIPTION
This works quite nice, in that you can choose your PS2 style button icons + Rebind controls. So to get PS3 style controls. Any button that is rebound to a face button will get pressure too, so you can bind action to Square, and it will work with CQC squeeze etc.